### PR TITLE
make plaintext for `rewardsPerBlock` more precise

### DIFF
--- a/src/views/DeployerViews.js
+++ b/src/views/DeployerViews.js
@@ -79,7 +79,7 @@ exports.SetOpts = class extends React.Component {
           />
           <br />
           <br />
-          <b>Rewards per block: </b>
+          <b>Maximum reward per block: </b>
           <input
             name='rewardsPerBlock'
             onChange={this.handleChange}


### PR DESCRIPTION
Since [this is the *maximum* reward per block](https://www.youtube.com/watch?v=PQw8GixxMlM&t=40s), it might be worth specifying that for the end-user.